### PR TITLE
Start adding CMOS opcodes documented at http://65xx.unet.bz/ds/R65C02…

### DIFF
--- a/disassemble.go
+++ b/disassemble.go
@@ -423,7 +423,7 @@ func (d *Disassembler) decode(op Opcode, bytes []byte, cursor uint) string {
 		if dvar, ok := d.lookupVar(uint(bytes[1])); ok {
 			return "(" + dvar + ")"
 		}
-		return fmt.Sprintf("(&%02X)")
+		return fmt.Sprintf("(&%02X)", bytes[1])
 	default:
 		return "UNKNOWN ADDRESS MODE"
 	}


### PR DESCRIPTION
….pdf for Domesday book analysis

Hi, So, you won't be able to take this wholesale because I've commented out some of the undocumented 6502 instructions in favor of the documented 65C102 ones.  It probably warrants a configuration option or command line switch to pick which instructions you want which will probably be a bigger refactor.  You should get to decide on the implementation.  I'm happy to put patches up once there's a decision on the way forward.  One of the bigger changes is that the new conditional branches on bit settings in a zero page address have 3 byte instructions... whee!

```\ ******************************************************************************
\
\ This disassembly was produced by bbcdisasm
\
\ ******************************************************************************

\ OS Call Addresses
OSASCI = &FFE3
OSNEWL = &FFE7
OSWRCH = &FFEE
OSWORD = &FFF1
OSBYTE = &FFF4
OSCLI  = &FFF7

\ OS Vector Addresses
USERV = &200
BRKV  = &202


CODE% = &E00

ORG CODE%

 LDX #&5C               \ &0E00 A2 5C       .\
 LDY #&4A               \ &0E02 A0 4A       .J
 JMP label_715          \ &0E04 4C 04 4D    L.M
 BRK                    \ &0E07 00          .
 NOP                    \ &0E08 EA          .
 NOP                    \ &0E09 EA          .
 ORA &5206              \ &0E0A 0D 06 52    ..R
 ROL &53                \ &0E0D 26 53       &S
 ASL &54                \ &0E0F 06 54       .T
 ROL &55                \ &0E11 26 55       &U
 CLC                    \ &0E13 18          .
 LDX #&04               \ &0E14 A2 04       ..
 LDY #&00               \ &0E16 A0 00       ..
.label_0
 LDA (&52),Y            \ &0E18 B1 52       .R
 ADC (&54),Y            \ &0E1A 71 54       qT
 STA (&54),Y            \ &0E1C 91 54       .T
 INY                    \ &0E1E C8          .
 DEX                    \ &0E1F CA          .
 BNE label_0            \ &0E20 D0 F6       ..
 LDX #&00               \ &0E22 A2 00       ..
 LDY #&00               \ &0E24 A0 00       ..
 BCC label_1            \ &0E26 90 04       ..
 LDX #&FF               \ &0E28 A2 FF       ..
 LDY #&FF               \ &0E2A A0 FF       ..
.label_1
 RTS                    \ &0E2C 60          `
 NOP                    \ &0E2D EA          .
 BBS5 &DF,label_2       \ &0E2E DF DF 07    ...
 RMB4 &2E               \ &0E31 47 2E       G.
 EOR &54,X              \ &0E33 55 54       UT
 ROL &5553              \ &0E35 2E 53 55    .SU
.label_2
 ORA &5206              \ &0E38 0D 06 52    ..R
```